### PR TITLE
Refactor date drop down and UI click handling

### DIFF
--- a/client/components/App.jsx
+++ b/client/components/App.jsx
@@ -99,8 +99,7 @@ const Reservation = styled.div`
   align-content: center;
   box-shadow: 1px 2px 8px rgba(153, 153, 153, 0.4);
   border-radius: 1%;
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen,
-    Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
+  font-family: 'Mukta Mahee', sans-serif;
 `;
 
 const Title = styled.h3`

--- a/client/components/Date.jsx
+++ b/client/components/Date.jsx
@@ -79,6 +79,8 @@ class Date extends React.Component {
     }
 
     // Format default text field for calendar drop down
+    var chosenDate = moment(this.props.date, 'YYYY-MM-DD');
+    var dateText = chosenDate.format('ddd') + ', ' + chosenDate.format('M/DD');
 
     const leftArrowStyle = {
       color: '#d8d9db'
@@ -88,7 +90,8 @@ class Date extends React.Component {
       <DateSection>
         <Title onClick={e => this.toggleCalendar(e)}>Date</Title>
         <CurrentDate onClick={e => this.toggleCalendar(e)}>
-          {this.props.date}
+          <div>{dateText}</div>
+          <i className="fas fa-angle-down" />
         </CurrentDate>
         <DateWrap id="dateWrap">
           <DateDrop>

--- a/client/components/Date.jsx
+++ b/client/components/Date.jsx
@@ -78,19 +78,18 @@ class Date extends React.Component {
       dates.push(oneWeek);
     }
 
+    // Format default text field for calendar drop down
+
     const leftArrowStyle = {
       color: '#d8d9db'
     };
 
     return (
       <DateSection>
-        <div
-          id="dateSelected"
-          className="title"
-          onClick={e => this.toggleCalendar(e)}
-        >
-          Date
-        </div>
+        <Title onClick={e => this.toggleCalendar(e)}>Date</Title>
+        <CurrentDate onClick={e => this.toggleCalendar(e)}>
+          {this.props.date}
+        </CurrentDate>
         <DateWrap id="dateWrap">
           <DateDrop>
             <Header>
@@ -121,23 +120,22 @@ class Date extends React.Component {
                 <Row key={week}>
                   {week.map(day => {
                     var classes = 'calendarBox';
+                    var onClick = () => {};
                     if (day.month() === month) {
                       classes += ' thisMonth';
                     }
                     if (moment().isSameOrBefore(day, 'day')) {
                       classes += ' future';
+                      onClick = e => {
+                        this.props.change(e, day.format('YYYY-MM-DD'));
+                        this.toggleCalendar(e);
+                      };
                     }
                     if (day.format('YYYY-MM-DD') === this.props.date) {
                       classes += ' defaultDate';
                     }
                     return (
-                      <div
-                        className={classes}
-                        key={day}
-                        onClick={e =>
-                          this.props.change(e, day.format('YYYY-MM-DD'))
-                        }
-                      >
+                      <div className={classes} key={day} onClick={onClick}>
                         {day.format('D')}
                       </div>
                     );
@@ -156,7 +154,29 @@ export default Date;
 
 const DateSection = styled.div`
   position: relative;
-  display: inline-block;
+  float: left;
+`;
+
+const Title = styled.div`
+  width: 140px;
+  height: 19px;
+  font-size: 85%;
+  font-weight: 600;
+`;
+
+const CurrentDate = styled.div`
+  border: 0px;
+  background-color: white;
+  width: 140px;
+  height: 34px;
+  border-bottom: 1px solid #d8d9db;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  &:hover {
+    cursor: pointer;
+    box-shadow: 0 1px 0 #da3743;
+  }
 `;
 
 const DateWrap = styled.div`

--- a/public/style.css
+++ b/public/style.css
@@ -1,6 +1,7 @@
 #app {
   display: inline-block;
 }
+
 .sideArrow {
   border: 1px solid #d8d9db;
   border-radius: 50%;


### PR DESCRIPTION
Calendar disappears on clicking text field, date heading, or date that is not past.
The date text field displays an abridged version of the user's currently selected date.
Ex: 'Mon, 02/18'