### PR TITLE
Update scripts for deployment and enable urls by id

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,4 +24,5 @@ coverage
 build/
 dist/
 public/bundle.js
+public/bundle.js.gz
 database/config.js

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,8 +7,8 @@ WORKDIR /src/app
 COPY . /src/app
 
 RUN npm install
-RUN npm run pack
+RUN npm run build
 
 EXPOSE 3003
 
-CMD ["sh","-c","npm run server && mysql -u root -h \"172.17.0.2\" -P 3306;"]
+CMD ["npm", "run", "server"]

--- a/README.md
+++ b/README.md
@@ -73,8 +73,8 @@ npm install
 Run server in nodemon to continuously watch for changes. Run webpack to continuously transpile to the server's entrypoint:
 
 ```sh
-npm run server
-npm run pack
+npm run server-dev
+npm run build-dev
 ```
 
 ### Testing

--- a/client/components/App.jsx
+++ b/client/components/App.jsx
@@ -11,8 +11,18 @@ const { styled } = window;
 class App extends React.Component {
   constructor(props) {
     super(props);
+
+    let id;
+    let paths = window.location.pathname.split('/');
+    let path = Number(paths[1]);
+    if (path > 0) {
+      id = path;
+    } else {
+      id = 1;
+    }
+
     this.state = {
-      restaurantId: Math.round(Math.random() * 100) || 1,
+      restaurantId: id,
       date: moment().format('YYYY-MM-DD'),
       time: '19:00',
       partySize: 2,
@@ -101,6 +111,7 @@ const Reservation = styled.div`
   box-shadow: 1px 2px 8px rgba(153, 153, 153, 0.4);
   border-radius: 1%;
   font-family: 'Mukta Mahee', sans-serif;
+  background-color: white;
 `;
 
 const Title = styled.h3`

--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
     "node": ">=6.13.0"
   },
   "scripts": {
-    "build": "webpack -d",
-    "build-dev": "webpack -d --watch",
+    "build": "webpack -p",
+    "build-dev": "webpack -p --watch",
     "mysql-seed": "mysql -u root < database/schema.sql",
     "server": "node server/server.js",
     "server-dev": "nodemon server/server.js",
@@ -26,7 +26,9 @@
     "react-dom": "^16.8.1",
     "request": "^2.88.0",
     "styled-components": "^4.1.3",
-    "underscore": "^1.9.1"
+    "uglifyjs-webpack-plugin": "^2.1.1",
+    "underscore": "^1.9.1",
+    "webpack": "^4.29.5"
   },
   "devDependencies": {
     "@babel/core": "^7.2.2",
@@ -34,6 +36,7 @@
     "@babel/preset-react": "^7.0.0",
     "babel-jest": "^24.1.0",
     "babel-loader": "^8.0.5",
+    "compression-webpack-plugin": "^2.0.0",
     "enzyme": "^3.8.0",
     "enzyme-adapter-react-16": "^1.9.1",
     "eslint-config-hackreactor": "git://github.com/reactorcore/eslint-config-hackreactor",

--- a/package.json
+++ b/package.json
@@ -8,9 +8,11 @@
     "node": ">=6.13.0"
   },
   "scripts": {
+    "build": "webpack -d",
+    "build-dev": "webpack -d --watch",
     "mysql-seed": "mysql -u root < database/schema.sql",
-    "pack": "webpack -d",
     "server": "node server/server.js",
+    "server-dev": "nodemon server/server.js",
     "test": "jest --verbose --coverage"
   },
   "dependencies": {

--- a/server/server.js
+++ b/server/server.js
@@ -14,6 +14,12 @@ const {
 
 let app = express();
 
+app.get('*.js', function(req, res, next) {
+  req.url = req.url + '.gz';
+  res.set('Content-Encoding', 'gzip');
+  next();
+});
+
 app.use(express.static(__dirname + '/../public'));
 app.use(morgan('dev'));
 app.use(bodyParser.json());

--- a/server/server.js
+++ b/server/server.js
@@ -124,6 +124,8 @@ app.post('/api/reserve/book/:id/:date/:time', (req, res) => {
   postTime(id, date, time, loadResponse);
 });
 
+app.use('/:id', express.static(__dirname + '/../public'));
+
 app.listen(port, err => {
   if (err) {
     console.error('Server error: ', err);

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,9 +1,14 @@
 var path = require('path');
+var uglifyJsPlugin = require('uglifyjs-webpack-plugin');
+var compressionPlugin = require('compression-webpack-plugin');
 module.exports = {
   entry: path.resolve(__dirname, './client/index.jsx'),
   output: {
     filename: 'bundle.js',
     path: path.resolve(__dirname, './public')
+  },
+  optimization: {
+    minimizer: [new uglifyJsPlugin()]
   },
   mode: 'development',
   devtool: 'inline-source-map',
@@ -24,7 +29,16 @@ module.exports = {
       }
     ]
   },
+  plugins: [
+    new compressionPlugin({
+      filename: '[path].gz[query]',
+      algorithm: 'gzip',
+      test: /\.js$|\.css$|\.html$/,
+      threshold: 10240,
+      minRatio: 0.8
+    })
+  ],
   externals: {
-    'styled-components': true,
+    'styled-components': true
   }
 };


### PR DESCRIPTION
The dockerfile, readme, and package.json consistently discriminate between development and deployment scripts.

The client no longer generates random restaurant id's; it reads the id from the window URL, or defaults to 1.